### PR TITLE
Fix login navigation and NFT image path

### DIFF
--- a/components/nft-inventory.tsx
+++ b/components/nft-inventory.tsx
@@ -186,7 +186,7 @@ export default function NFTInventory({
         name: itemName,
         description: itemDescription,
         uri: `ipfs://adventure-${Date.now()}`,
-        image: `/images/inventory/${selectedType}-${selectedRarity}.png`,
+        image: `${selectedType}-${selectedRarity}.png`,
         attributes: [
           { trait_type: "Type", value: selectedType },
           { trait_type: "Rarity", value: selectedRarity },
@@ -220,7 +220,7 @@ export default function NFTInventory({
           description: itemDescription,
           type: selectedType,
           rarity: selectedRarity,
-          image: `/images/inventory/${selectedType}-${selectedRarity}.png`,
+          image: `${selectedType}-${selectedRarity}.png`,
           tokenId: result.tokenId,
           txHash: result.txHash,
           mintedAt: new Date().toISOString(),

--- a/components/wallet-status.tsx
+++ b/components/wallet-status.tsx
@@ -95,11 +95,8 @@ export default function WalletStatus() {
         description: "กำลังนำทางไปยังหน้าเกม...",
       });
 
-      // หน่วงเวลาเล็กน้อยเพื่อให้ toast แสดงก่อนนำทาง
-      setTimeout(() => {
-        // นำทางไปยัง dashboard ด้วย window.location.href เพื่อให้แน่ใจว่ามีการโหลดหน้าใหม่
-        window.location.href = "/dashboard";
-      }, 500);
+      // นำทางไปยังหน้าเกมเมื่อเตรียมข้อมูลเสร็จแล้ว
+      router.push("/dashboard");
     } catch (error) {
       console.error("Error preparing game entry:", error);
 
@@ -113,10 +110,8 @@ export default function WalletStatus() {
         60 * 60 * 24 * 30
       }; SameSite=Lax`;
 
-      // นำทางไปยัง dashboard แม้จะมีข้อผิดพลาด ด้วย window.location.href
-      setTimeout(() => {
-        window.location.href = "/dashboard";
-      }, 1000);
+      // พยายามนำทางไปยังหน้าเกมแม้เกิดข้อผิดพลาด
+      router.push("/dashboard");
     } finally {
       setIsNavigating(false);
     }


### PR DESCRIPTION
## Summary
- navigate to dashboard with Next router instead of full reload
- store only image filename when minting inventory items

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_683f8cdac02c832d9641090715a7d343