### PR TITLE
Fix registerPlayer result handling

### DIFF
--- a/app/dashboard/page-client.tsx
+++ b/app/dashboard/page-client.tsx
@@ -87,7 +87,7 @@ export default function DashboardClient({
 
       const result = await registerPlayer();
 
-      if (result && result.hash) {
+      if (result && result.txHash) {
         toast.success("ลงทะเบียนสำเร็จ", {
           description: "ตอนนี้คุณสามารถเล่นเกมบนบล็อกเชนได้แล้ว!",
         });

--- a/lib/web3-client.tsx
+++ b/lib/web3-client.tsx
@@ -41,6 +41,14 @@ import {
 let isWalletConnectInitialized = false;
 
 // Web3 Context Type
+interface RegisterPlayerResult {
+  success: boolean;
+  txHash?: string;
+  error?: string;
+  message?: string;
+  simulated?: boolean;
+}
+
 interface Web3ContextType {
   address: string | null;
   chainId: number | null;
@@ -58,7 +66,7 @@ interface Web3ContextType {
   batchUpgradeCharacters: (characterIds: number[]) => Promise<any>;
   changeArea: (newArea: string) => Promise<any>;
   gainExperience: (characterId: number, amount: number) => Promise<any>;
-  registerPlayer: () => Promise<any>;
+  registerPlayer: () => Promise<RegisterPlayerResult>;
   isPlayerRegistered: (address: string) => Promise<boolean>;
   batchTransactions: (
     transactions: Array<{
@@ -106,7 +114,7 @@ const Web3Context = createContext<Web3ContextType>({
   batchUpgradeCharacters: async () => ({}),
   changeArea: async () => ({}),
   gainExperience: async () => ({}),
-  registerPlayer: async () => ({}),
+  registerPlayer: async () => ({ success: false }),
   isPlayerRegistered: async () => false,
   batchTransactions: async () => ({}),
   autoAttack: async () => ({}),


### PR DESCRIPTION
## Summary
- check `txHash` when registering on the blockchain
- add `RegisterPlayerResult` type and use it in the Web3 context

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_683f8a50bbe0832d823c2b132068b5b5